### PR TITLE
fix Lakebed Temple Ooccoo flag

### DIFF
--- a/Scripts/flags.js
+++ b/Scripts/flags.js
@@ -2263,7 +2263,7 @@ const flags = new Map([
     })],
     ["Lakebed Temple Ooccoo", new Flag(ooccooPot, [-4490, 4552], {
         baseReqs: [bombBagReq, [bowReq, boomerangReq]],
-        baseReqs: 'Pick up or break the pot where Ooccoo is hiding.'
+        baseDesc: 'Pick up or break the pot where Ooccoo is hiding.'
     })],
     ["Lakebed Temple Main Room Lock", new Flag(lock, [-4372, 4666], {
         baseReqs: [bombBagReq, [bowReq, boomerangReq], lakebed1SKReq],


### PR DESCRIPTION
Fixes a small typo that caused the button for the flag to not work, and also caused some of the other flags on lakebed 2F to not appear.